### PR TITLE
replace accessor functions

### DIFF
--- a/src/css/_functions.scss
+++ b/src/css/_functions.scss
@@ -6,6 +6,16 @@
  * defined based on those variables, you should use the accessor functions in
  * this module to reference the value. This ensures that you don't accidentally
  * use a custom property that wasn't defined.
+ *
+ * Example:
+ *
+ *    @use "../functions" as f;
+ *
+ *    .my-component {
+ *      color: f.color(text, default);
+ *    }
+ *
+ * Alternatively, use the tokens forwarded by _tokens.scss.
  */
 
 @use "../../build/tokens/scss/tokens.light.scss" as t;

--- a/src/css/_functions.scss
+++ b/src/css/_functions.scss
@@ -18,7 +18,7 @@
  * Alternatively, use the tokens forwarded by _tokens.scss.
  */
 
-@use "../../build/tokens/scss/tokens.light.scss" as t;
+@use "../../build/tokens/scss/tokens.scss" as t;
 @use "sass:list";
 @use "sass:map";
 @use "sass:math";

--- a/src/css/_tokens.scss
+++ b/src/css/_tokens.scss
@@ -18,4 +18,4 @@
  * Alternatively, use the accessor functions defined in _functions.scss.
  */
 
-@forward "../../build/tokens/scss/properties.light";
+@forward "../../build/tokens/scss/variables";

--- a/src/css/_tokens.scss
+++ b/src/css/_tokens.scss
@@ -1,0 +1,21 @@
+/**
+ * This module forwards the variables for the design tokens and defines
+ * additional variables.
+ *
+ * The variables forwarded from the token definitions have CSS custom properties
+ * as values. This way, the final CSS output will use custom properties, but
+ * you have the additional safety that unknown variables will result in a
+ * build failure.
+ *
+ * Example:
+ *
+ *    @use "../tokens" as t;
+ *
+ *    .my-component {
+ *      color: t.$color-text-default;
+ *    }
+ *
+ * Alternatively, use the accessor functions defined in _functions.scss.
+ */
+
+@forward "../../build/tokens/scss/properties.light";

--- a/style-dictionary.js
+++ b/style-dictionary.js
@@ -36,6 +36,18 @@ StyleDictionary.registerFilter({
 });
 
 StyleDictionary.registerFormat({
+  name: "scss/custom-properties",
+  format: async function ({ dictionary, file }) {
+    return (
+      (await fileHeader({ file })) +
+      dictionary.allTokens
+        .map((prop) => `$${prop.name}: --${prop.name};`)
+        .join("\n")
+    );
+  },
+});
+
+StyleDictionary.registerFormat({
   name: "scss/mixin",
   format: async function ({ dictionary, file, options = {} }) {
     const {
@@ -78,7 +90,14 @@ const platforms = (theme = "") => {
           format: "scss/mixin",
         },
         {
-          destination: `tokens${theme}.scss`,
+          destination: `_properties${theme}.scss`,
+          filter: (token) => {
+            return !isBaseColor(token) && !isInternal(token);
+          },
+          format: "scss/custom-properties",
+        },
+        {
+          destination: `_tokens${theme}.scss`,
           filter: "noBaseColors",
           format: "scss/map-deep",
         },

--- a/style-dictionary.js
+++ b/style-dictionary.js
@@ -116,16 +116,6 @@ const platforms = (theme = "") => {
         },
       ],
     },
-    js: {
-      transformGroup: "js",
-      buildPath: "build/tokens/js/",
-      files: [
-        {
-          destination: `tokens${theme}.js`,
-          format: "javascript/es6",
-        },
-      ],
-    },
     json: {
       transformGroup: "js",
       buildPath: "build/tokens/json/",


### PR DESCRIPTION
- **add custom properties formatter**
- **expose SASS variables mapping to custom properties**
- **remove js platform**
- **generate some formats once for all themes**
